### PR TITLE
Switch pymapd to be conda dep instead of pip dep

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,8 @@ dependencies:
   - altair
   - pyyaml
   - mypy
+  - pymapd
   - pip:
     - vdom
     - vega_datasets
-    - pymapd
     - https://github.com/ibis-project/ibis/archive/master.zip


### PR DESCRIPTION
We can't seem to install pymapd via pip :(