### PR TITLE
Connection manager

### DIFF
--- a/schema/connection.json
+++ b/schema/connection.json
@@ -34,7 +34,7 @@
           "type": "string"
         },
         "port": {
-          "type": "integer"
+          "type": ["integer", "string"]
         },
         "GTM": {
           "type": "string"

--- a/schema/connection.json
+++ b/schema/connection.json
@@ -128,6 +128,11 @@
       "items": {
         "$ref": "#/definitions/connection"
       }
+    },
+    "environment": {
+      "title": "Connection configuration in environment varaibles",
+      "description": "Any properties given here are taken to be environment variables\nand used in python connection code.",
+      "$ref": "#/definitions/connection"
     }
   },
   "additionalProperties": false,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -4,6 +4,8 @@ import { CompletionHandler } from '@jupyterlab/completer';
 
 import { DataConnector } from '@jupyterlab/coreutils';
 
+import { ISignal, Signal } from '@phosphor/signaling';
+
 import { PanelLayout, Widget } from '@phosphor/widgets';
 
 declare const require: any;
@@ -86,6 +88,32 @@ export interface IOmniSciConnectionData {
    * Not used here.
    */
   loadDashboard?: any;
+}
+
+export interface IOmniSciConnectionManager {
+  readonly defaultConnection: IOmniSciConnectionData | undefined;
+
+  readonly connections: ReadonlyArray<IOmniSciConnectionData>;
+
+  readonly changed: ISignal<this, void>;
+}
+
+export class OmniSciConnectionManager {
+  get defaultConnection(): IOmniSciConnectionData | undefined {
+    return this._defaultConnection;
+  }
+
+  get connections(): ReadonlyArray<IOmniSciConnectionData> {
+    return this._connections;
+  }
+
+  get changed(): ISignal<this, void> {
+    return this._changed;
+  }
+
+  private _defaultConnection: IOmniSciConnectionData | undefined;
+  private _changed = new Signal<this, void>(this);
+  private _connections: IOmniSciConnectionData[] = [];
 }
 
 /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -22,7 +22,7 @@ declare const MapdCon: any;
 /**
  * The OmniSciConnectionManager token.
  */
-const IOmniSciConnectionManager = new Token<IOmniSciConnectionManager>(
+export const IOmniSciConnectionManager = new Token<IOmniSciConnectionManager>(
   'jupyterlab-omnisci:IOmniSciConnectionManager'
 );
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -619,11 +619,14 @@ namespace Private {
     if (data.url) {
       let { hostname, port, protocol } = URLExt.parse(data.url);
       let portN: number;
+      // Fill in the port with defaults if necessary.
       if (port) {
         portN = parseInt(port, 10);
       } else {
         portN = protocol === 'http' ? 80 : port === 'https' ? 443 : NaN;
       }
+      // Remove ':' characters from the protocol.
+      protocol = protocol ? protocol.replace(':', '') : '';
 
       const newData: IOmniSciConnectionData = {
         ...data,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -92,7 +92,7 @@ export interface IOmniSciConnectionData {
   /**
    * The port for the connection.
    */
-  port?: number;
+  port?: number | string;
 
   /**
    * GTM string.
@@ -650,7 +650,7 @@ namespace Private {
     // Assume https if protocol is undefined.
     protocol = (protocol || 'https').replace(':', '');
     port = port
-      ? port
+      ? parseInt(`${port}`, 10)
       : protocol === 'http'
       ? 80
       : protocol === 'https'

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -145,6 +145,15 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
     return this._defaultConnection;
   }
   set defaultConnection(value: IOmniSciConnectionData) {
+    // Do nothing if there is no change.
+    if (
+      JSONExt.deepEqual(
+        this._defaultConnection as JSONObject,
+        value as JSONObject
+      )
+    ) {
+      return;
+    }
     value.master = false; // Temporarily set to false;
     let servers = this._connections.slice();
     // First loop through the existing servers and unset the master attribute.
@@ -154,8 +163,11 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
     // Next loop through the existing servers and see if one already matches
     // the new server.
     const match = servers.find(s => {
-      // TODO: make this forgiving.
-      return JSONExt.deepEqual(s as JSONObject, value as JSONObject);
+      return (
+        Object.keys(value).filter(
+          (key: keyof IOmniSciConnectionData) => value[key] !== s[key]
+        ).length === 0
+      );
     });
 
     // If we found one, set it to the master server.

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -230,6 +230,18 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
   get environment(): IOmniSciConnectionData | undefined {
     return this._environment;
   }
+  set environment(value: IOmniSciConnectionData | undefined) {
+    if (
+      (!value && !this._environment) ||
+      JSONExt.deepEqual(value as JSONObject, this._environment as JSONObject)
+    ) {
+      return;
+    } else if (!value) {
+      this._settings.remove('environment');
+      return;
+    }
+    this._settings.set('environment', value as JSONObject);
+  }
 
   /**
    * The overall list of connections known to the manager.

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -616,31 +616,37 @@ namespace Private {
   export function normalizeConnectionData(
     data: IOmniSciConnectionData
   ): IOmniSciConnectionData {
-    if (data.url) {
-      let { hostname, port, protocol } = URLExt.parse(data.url);
+    let { host, port, protocol } = data;
 
-      // Assume https if protocol is undefined.
-      protocol = protocol || 'https';
-      // Remove ':' characters from the protocols
-      protocol = protocol ? protocol.replace(':', '') : '';
+    // Assume https if protocol is undefined.
+    protocol = (protocol || 'https').replace(':', '');
+    port = port
+      ? port
+      : protocol === 'http'
+        ? 80
+        : protocol === 'https'
+          ? 443
+          : NaN;
+
+    if (data.url) {
+      const parsed = URLExt.parse(data.url);
+      protocol = parsed.protocol;
+      host = parsed.hostname;
+      protocol = (protocol || 'https').replace(':', '');
 
       // Fill in the port with defaults if necessary.
-      let portN: number;
-      if (port) {
-        portN = parseInt(port, 10);
+      if (parsed.port) {
+        port = parseInt(parsed.port, 10);
       } else {
-        portN = protocol === 'http' ? 80 : port === 'https' ? 443 : NaN;
+        port = protocol === 'http' ? 80 : protocol === 'https' ? 443 : NaN;
       }
-
-      const newData: IOmniSciConnectionData = {
-        ...data,
-        host: hostname,
-        port: portN,
-        protocol
-      };
-      return newData;
     }
-    return data;
+    return {
+      ...data,
+      host,
+      port,
+      protocol
+    };
   }
 
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -312,8 +312,7 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
     const environment = settings.get('environment').composite as
       | IOmniSciConnectionData
       | undefined;
-    this._environment =
-      environment && Private.normalizeConnectionData(environment);
+    this._environment = environment;
     this._defaultConnection = Private.chooseDefault(this.connections);
     this._changed.emit(void 0);
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -234,7 +234,7 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
     label: string,
     oldData?: IOmniSciConnectionData
   ): Promise<IOmniSciConnectionData | undefined> {
-    return showConnectionDialog(label, oldData, this.connections);
+    return Private.showConnectionDialog(label, oldData, this.connections);
   }
 
   /**
@@ -313,30 +313,6 @@ export namespace OmniSciConnectionManager {
      */
     settings: ISettingRegistry.ISettings;
   }
-}
-
-/**
- * Show a dialog for entering OmniSci connection data.
- */
-export function showConnectionDialog(
-  title: string,
-  oldConnection?: IOmniSciConnectionData,
-  knownServers?: ReadonlyArray<IOmniSciConnectionData>
-): Promise<IOmniSciConnectionData | undefined> {
-  return showDialog<IOmniSciConnectionData>({
-    title,
-    body: new OmniSciConnectionDialog({
-      knownServers,
-      oldData: oldConnection
-    }),
-    buttons: [Dialog.cancelButton(), Dialog.okButton()]
-  }).then(result => {
-    if (result.button.accept) {
-      return result.value || oldConnection;
-    } else {
-      return oldConnection;
-    }
-  });
 }
 
 /**
@@ -670,5 +646,29 @@ namespace Private {
       return newData;
     }
     return data;
+  }
+
+  /**
+   * Show a dialog for entering OmniSci connection data.
+   */
+  export function showConnectionDialog(
+    title: string,
+    oldConnection?: IOmniSciConnectionData,
+    knownServers?: ReadonlyArray<IOmniSciConnectionData>
+  ): Promise<IOmniSciConnectionData | undefined> {
+    return showDialog<IOmniSciConnectionData>({
+      title,
+      body: new OmniSciConnectionDialog({
+        knownServers,
+        oldData: oldConnection
+      }),
+      buttons: [Dialog.cancelButton(), Dialog.okButton()]
+    }).then(result => {
+      if (result.button.accept) {
+        return result.value || oldConnection;
+      } else {
+        return oldConnection;
+      }
+    });
   }
 }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -152,10 +152,7 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
    */
   constructor(options: OmniSciConnectionManager.IOptions) {
     this._settings = options.settings;
-    this._settings.changed.connect(
-      this._onSettingsChanged,
-      this
-    );
+    this._settings.changed.connect(this._onSettingsChanged, this);
     this._onSettingsChanged(this._settings);
     void this._fetchImmerseServers();
   }
@@ -655,10 +652,10 @@ namespace Private {
     port = port
       ? port
       : protocol === 'http'
-        ? 80
-        : protocol === 'https'
-          ? 443
-          : NaN;
+      ? 80
+      : protocol === 'https'
+      ? 443
+      : NaN;
 
     if (data.url) {
       const parsed = URLExt.parse(data.url);

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -618,15 +618,19 @@ namespace Private {
   ): IOmniSciConnectionData {
     if (data.url) {
       let { hostname, port, protocol } = URLExt.parse(data.url);
-      let portN: number;
+
+      // Assume https if protocol is undefined.
+      protocol = protocol || 'https';
+      // Remove ':' characters from the protocols
+      protocol = protocol ? protocol.replace(':', '') : '';
+
       // Fill in the port with defaults if necessary.
+      let portN: number;
       if (port) {
         portN = parseInt(port, 10);
       } else {
         portN = protocol === 'http' ? 80 : port === 'https' ? 443 : NaN;
       }
-      // Remove ':' characters from the protocol.
-      protocol = protocol ? protocol.replace(':', '') : '';
 
       const newData: IOmniSciConnectionData = {
         ...data,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -129,11 +129,6 @@ export interface IOmniSciConnectionManager extends IDisposable {
   ): Promise<IOmniSciConnectionData | undefined>;
 
   /**
-   * Make a connection to the Omnisci backend.
-   */
-  makeConnection(data: IOmniSciConnectionData): Promise<OmniSciConnection>;
-
-  /**
    * A signal that fires when the connection listing changes.
    */
   readonly changed: ISignal<this, void>;
@@ -235,13 +230,6 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
     oldData?: IOmniSciConnectionData
   ): Promise<IOmniSciConnectionData | undefined> {
     return Private.showConnectionDialog(label, oldData, this.connections);
-  }
-
-  /**
-   * Make a connection to the Omnisci backend.
-   */
-  makeConnection(data: IOmniSciConnectionData): Promise<OmniSciConnection> {
-    return makeConnection(data);
   }
 
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -121,6 +121,19 @@ export interface IOmniSciConnectionManager extends IDisposable {
   readonly connections: ReadonlyArray<IOmniSciConnectionData>;
 
   /**
+   * Prompt user to choose a connection.
+   */
+  chooseConnection(
+    label: string,
+    oldData?: IOmniSciConnectionData
+  ): Promise<IOmniSciConnectionData | undefined>;
+
+  /**
+   * Make a connection to the Omnisci backend.
+   */
+  makeConnection(data: IOmniSciConnectionData): Promise<OmniSciConnection>;
+
+  /**
    * A signal that fires when the connection listing changes.
    */
   readonly changed: ISignal<this, void>;
@@ -215,6 +228,23 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
   }
 
   /**
+   * Prompt user to choose a connection.
+   */
+  chooseConnection(
+    label: string,
+    oldData?: IOmniSciConnectionData
+  ): Promise<IOmniSciConnectionData | undefined> {
+    return showConnectionDialog(label, oldData, this.connections);
+  }
+
+  /**
+   * Make a connection to the Omnisci backend.
+   */
+  makeConnection(data: IOmniSciConnectionData): Promise<OmniSciConnection> {
+    return makeConnection(data);
+  }
+
+  /**
    * Dispose of the connection manager.
    */
   dispose(): void {
@@ -295,7 +325,10 @@ export function showConnectionDialog(
 ): Promise<IOmniSciConnectionData | undefined> {
   return showDialog<IOmniSciConnectionData>({
     title,
-    body: new OmniSciConnectionDialog({ knownServers, oldData: oldConnection }),
+    body: new OmniSciConnectionDialog({
+      knownServers,
+      oldData: oldConnection
+    }),
     buttons: [Dialog.cancelButton(), Dialog.okButton()]
   }).then(result => {
     if (result.button.accept) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -134,6 +134,13 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
     this._onSettingsChanged(this._settings);
   }
 
+  /**
+   * The default connection data.
+   *
+   * #### Notes
+   * Setting the default triggers an asynchronous write to the settings
+   * system. The changed signal will not fire until that is complete.
+   */
   get defaultConnection(): IOmniSciConnectionData {
     return this._defaultConnection;
   }
@@ -162,23 +169,39 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
     this._settings.set('servers', (servers as unknown) as JSONObject);
   }
 
+  /**
+   * The overall list of connections known to the manager.
+   */
   get connections(): ReadonlyArray<IOmniSciConnectionData> {
     return this._connections;
   }
 
+  /**
+   * A signal that fires when the list of connections changes.
+   */
   get changed(): ISignal<this, void> {
     return this._changed;
   }
 
+  /**
+   * Dispose of the connection manager.
+   */
   dispose(): void {
     this._isDisposed = true;
     Signal.clearData(this);
   }
 
+  /**
+   * Whether the connection manager is disposed.
+   */
   get isDisposed(): boolean {
     return this._isDisposed;
   }
 
+  /**
+   * React to the settings changing.
+   * This emits the `changed` signal once it is done.
+   */
   private _onSettingsChanged(settings: ISettingRegistry.ISettings): void {
     const newServers = (settings.get('servers').composite as unknown) as
       | IOmniSciConnectionData[]

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -116,6 +116,18 @@ export interface IOmniSciConnectionManager extends IDisposable {
   readonly defaultConnection: IOmniSciConnectionData | undefined;
 
   /**
+   * A connection specifying properties that are stored
+   * in environment variables. For places where code is submitted
+   * to kernels, this may be used to pull from environment variables
+   * instead of supplying credentials from the settings system.
+   *
+   * #### Notes
+   * This is not used for client-side connections like the SQL editor,
+   * as they do not have access to environment variables.
+   */
+  readonly environment: IOmniSciConnectionData | undefined;
+
+  /**
    * A list of predefined connections.
    */
   readonly connections: ReadonlyArray<IOmniSciConnectionData>;
@@ -209,6 +221,20 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
   }
 
   /**
+   * A connection specifying properties that are stored
+   * in environment variables. For places where code is submitted
+   * to kernels, this may be used to pull from environment variables
+   * instead of supplying credentials from the settings system.
+   *
+   * #### Notes
+   * This is not used for client-side connections like the SQL editor,
+   * as they do not have access to environment variables.
+   */
+  get environment(): IOmniSciConnectionData | undefined {
+    return this._environment;
+  }
+
+  /**
    * The overall list of connections known to the manager.
    */
   get connections(): ReadonlyArray<IOmniSciConnectionData> {
@@ -258,6 +284,11 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
         | undefined) || [];
     // Combine the settings connection data with any immerse connection data.
     this._labConnections = newServers.map(Private.normalizeConnectionData);
+    const environment = settings.get('environment').composite as
+      | IOmniSciConnectionData
+      | undefined;
+    this._environment =
+      environment && Private.normalizeConnectionData(environment);
     this._defaultConnection = Private.chooseDefault(this.connections);
     this._changed.emit(void 0);
   }
@@ -283,6 +314,7 @@ export class OmniSciConnectionManager implements IOmniSciConnectionManager {
   private _settings: ISettingRegistry.ISettings;
   private _isDisposed = false;
   private _defaultConnection: IOmniSciConnectionData | undefined = undefined;
+  private _environment: IOmniSciConnectionData | undefined = undefined;
   private _changed = new Signal<this, void>(this);
   private _labConnections: ReadonlyArray<IOmniSciConnectionData> = [];
   private _immerseConnections: ReadonlyArray<IOmniSciConnectionData> = [];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -384,7 +384,7 @@ function activateOmniSciGridViewer(
       const query = (args['initialQuery'] as string) || '';
       const grid = new OmniSciSQLEditor({
         editorFactory: editorServices.factoryService.newInlineEditor,
-        connectionData: manager.defaultConnection
+        manager
       });
       grid.content.query = query;
       grid.id = `omnisci-grid-widget-${++Private.id}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,8 +36,7 @@ import {
   IOmniSciConnectionData,
   IOmniSciConnectionManager,
   OmniSciCompletionConnector,
-  OmniSciConnectionManager,
-  showConnectionDialog
+  OmniSciConnectionManager
 } from './connection';
 
 import { OmniSciSQLEditor } from './grid';
@@ -119,14 +118,12 @@ async function activateOmniSciConnection(
 
   // Add an application-wide connection-setting command.
   app.commands.addCommand(CommandIDs.setConnection, {
-    execute: () => {
-      showConnectionDialog(
+    execute: async () => {
+      const connection = await manager.chooseConnection(
         'Set Default Omnisci Connection',
-        manager.defaultConnection,
-        manager.connections
-      ).then(connection => {
-        manager.defaultConnection = connection;
-      });
+        manager.defaultConnection
+      );
+      manager.defaultConnection = connection;
     },
     label: 'Set Default Omnisci Connection...'
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -577,8 +577,8 @@ namespace Private {
 import ibis
 
 con = ibis.mapd.connect(
-    host='{{host}}', user='{{user}}', password='{{password}}',
-    port={{port}}, database='{{database}}', protocol='{{protocol}}'
+    host={{host}}, user={{user}}, password={{password}},
+    port={{port}}, database={{database}}, protocol={{protocol}}
 )
 
 con.list_tables()`.trim();
@@ -602,17 +602,19 @@ con.list_tables()`.trim();
       'database'
     ];
     keys.forEach(key => {
-      con[key] = env[key] ? `os.environ[${env[key]}` : connection[key];
+      con[key] = connection[key]
+        ? `'${connection[key]}'`
+        : `os.environ['${env[key]}']`;
     });
 
     let value = IBIS_TEMPLATE;
     value = value.replace('{{os}}', os);
-    value = value.replace('{{host}}', con.host || '');
-    value = value.replace('{{protocol}}', con.protocol || '');
-    value = value.replace('{{password}}', con.password || '');
-    value = value.replace('{{database}}', con.database || '');
-    value = value.replace('{{user}}', con.username || '');
-    value = value.replace('{{port}}', `${con.port || ''}`);
+    value = value.replace('{{host}}', con.host || "''");
+    value = value.replace('{{protocol}}', con.protocol || "''");
+    value = value.replace('{{password}}', con.password || "''");
+    value = value.replace('{{database}}', con.database || "''");
+    value = value.replace('{{user}}', con.username || "''");
+    value = value.replace('{{port}}', `${con.port || "''"}`);
     NotebookActions.insertAbove(notebook);
     notebook.model.cells.get(0)!.value.text = value;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,7 +168,8 @@ function activateOmniSciVegaViewer(
     modelName: 'text',
     fileTypes: ['json', 'omnisci-vega', 'vega3', 'vega4'],
     defaultFor: ['omnisci-vega'],
-    readOnly: true
+    readOnly: true,
+    manager
   });
   const viewerTracker = new InstanceTracker<OmniSciVegaViewer>({
     namespace: viewerNamespace
@@ -199,7 +200,6 @@ function activateOmniSciVegaViewer(
   // have it defined.
   manager.changed.connect(() => {
     const defaultConnectionData = manager.defaultConnection;
-    factory.defaultConnectionData = defaultConnectionData;
     viewerTracker.forEach(viewer => {
       if (!viewer.connectionData) {
         viewer.connectionData = defaultConnectionData;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,6 +65,8 @@ namespace CommandIDs {
 
   export const setConnection = 'omnisci:set-connection';
 
+  export const setEnvironment = 'omnisci:set-environment';
+
   export const injectIbisConnection = 'omnisci:inject-ibis-connection';
 }
 
@@ -128,8 +130,27 @@ async function activateOmniSciConnection(
     label: 'Set Default Omnisci Connection...'
   });
 
-  mainMenu.settingsMenu.addGroup([{ command: CommandIDs.setConnection }], 50);
+  // Add an application-wide connection-setting command.
+  app.commands.addCommand(CommandIDs.setEnvironment, {
+    execute: async () => {
+      const connection = await manager.chooseConnection(
+        'Set OmniSci Connection Environment Variables',
+        manager.environment
+      );
+      manager.environment = connection;
+    },
+    label: 'Set OmniSci Connection Environment...'
+  });
+
+  mainMenu.settingsMenu.addGroup(
+    [
+      { command: CommandIDs.setConnection },
+      { command: CommandIDs.setEnvironment }
+    ],
+    50
+  );
   palette.addItem({ command: CommandIDs.setConnection, category: 'OmniSci' });
+  palette.addItem({ command: CommandIDs.setEnvironment, category: 'OmniSci' });
 
   return manager;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,7 @@ async function activateOmniSciConnection(
         manager.defaultConnection,
         manager.connections
       ).then(connection => {
-        manager.defaultConnection = connection || {};
+        manager.defaultConnection = connection;
       });
     },
     label: 'Set Default Omnisci Connection...'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,7 @@ async function activateOmniSciConnection(
         manager.defaultConnection,
         manager.connections
       ).then(connection => {
-        manager.defaultConnection = connection;
+        manager.defaultConnection = connection || {};
       });
     },
     label: 'Set Default Omnisci Connection...'
@@ -193,8 +193,8 @@ function activateOmniSciVegaViewer(
     const types = app.docRegistry.getFileTypesForPath(widget.context.path);
 
     if (types.length > 0) {
-      widget.title.iconClass = types[0].iconClass;
-      widget.title.iconLabel = types[0].iconLabel;
+      widget.title.iconClass = types[0].iconClass || '';
+      widget.title.iconLabel = types[0].iconLabel || '';
     }
   });
 
@@ -280,7 +280,9 @@ function activateOmniSciGridViewer(
 
   // Keep the themes up-to-date.
   const updateThemes = () => {
-    const isLight = themeManager.isLight(themeManager.theme);
+    const isLight = themeManager.theme
+      ? themeManager.isLight(themeManager.theme)
+      : true;
     style = isLight ? Private.LIGHT_STYLE : Private.DARK_STYLE;
     renderer = isLight ? Private.LIGHT_RENDERER : Private.DARK_RENDERER;
     gridTracker.forEach(grid => {
@@ -333,7 +335,11 @@ function activateOmniSciGridViewer(
       const current = app.shell.currentWidget;
       if (current && current === gridTracker.currentWidget) {
         anchor = gridTracker.currentWidget;
-      } else if (current && current.contains(mimeGridTracker.currentWidget)) {
+      } else if (
+        current &&
+        mimeGridTracker.currentWidget &&
+        current.contains(mimeGridTracker.currentWidget)
+      ) {
         anchor = mimeGridTracker.currentWidget;
       }
       if (anchor) {
@@ -349,7 +355,11 @@ function activateOmniSciGridViewer(
       const current = app.shell.currentWidget;
       if (current && current === gridTracker.currentWidget) {
         anchor = gridTracker.currentWidget;
-      } else if (current && current.contains(mimeGridTracker.currentWidget)) {
+      } else if (
+        current &&
+        mimeGridTracker.currentWidget &&
+        current.contains(mimeGridTracker.currentWidget)
+      ) {
         anchor = mimeGridTracker.currentWidget;
       }
       if (anchor) {
@@ -442,12 +452,12 @@ function activateOmniSciInitialNotebook(
     label: 'Inject Ibis OmniSci Connection',
     execute: () => {
       const current = tracker.currentWidget;
-      if (!current || Private.connectionPopulated(manager.defaultConnection)) {
+      if (!current || !Private.connectionPopulated(manager.defaultConnection)) {
         return;
       }
       Private.injectIbisConnection(
         current.content.model,
-        manager.defaultConnection
+        manager.defaultConnection!
       );
     },
     isEnabled: () => !!tracker.currentWidget
@@ -492,7 +502,7 @@ function activateOmniSciInitialNotebook(
           if (!Private.connectionPopulated(manager.defaultConnection)) {
             return;
           }
-          Private.injectIbisConnection(sender, manager.defaultConnection);
+          Private.injectIbisConnection(sender, manager.defaultConnection!);
           notebook.content.model.contentChanged.disconnect(inject);
         }
       };
@@ -577,20 +587,23 @@ con.list_tables()`.trim();
     connection: IOmniSciConnectionData
   ) {
     let value = IBIS_TEMPLATE;
-    value = value.replace('{{host}}', connection.host);
-    value = value.replace('{{protocol}}', connection.protocol);
-    value = value.replace('{{password}}', connection.password);
-    value = value.replace('{{database}}', connection.database);
-    value = value.replace('{{user}}', connection.username);
-    value = value.replace('{{port}}', `${connection.port}`);
-    model.cells.get(0).value.text = value;
+    value = value.replace('{{host}}', connection.host || '');
+    value = value.replace('{{protocol}}', connection.protocol || '');
+    value = value.replace('{{password}}', connection.password || '');
+    value = value.replace('{{database}}', connection.database || '');
+    value = value.replace('{{user}}', connection.username || '');
+    value = value.replace('{{port}}', `${connection.port || ''}`);
+    model.cells.get(0)!.value.text = value;
   }
 
   /**
    * Test whether a partial connection is complete enough to be successful.
    */
-  export function connectionPopulated(con: IOmniSciConnectionData): boolean {
+  export function connectionPopulated(
+    con: IOmniSciConnectionData | undefined
+  ): boolean {
     return !!(
+      con &&
       con.host &&
       con.protocol &&
       con.password &&

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,12 +28,7 @@ import {
   NotebookModel
 } from '@jupyterlab/notebook';
 
-import {
-  JSONExt,
-  JSONObject,
-  PromiseDelegate,
-  Token
-} from '@phosphor/coreutils';
+import { JSONExt, JSONObject, PromiseDelegate } from '@phosphor/coreutils';
 
 import { DataGrid, TextRenderer } from '@phosphor/datagrid';
 
@@ -41,7 +36,6 @@ import { Widget } from '@phosphor/widgets';
 
 import {
   IOmniSciConnectionData,
-  IOmniSciConnectionManager,
   OmniSciCompletionConnector,
   showConnectionDialog
 } from './connection';
@@ -59,15 +53,6 @@ import {
  * The name of the factory that creates pdf widgets.
  */
 const FACTORY = 'OmniSciVega';
-
-/* tslint:disable */
-/**
- * The OmniSciConnectionManager token.
- */
-const IOmniSciConnectionManager = new Token<IOmniSciConnectionManager>(
-  'jupyterlab-omnisci:IOmniSciConnectionManager'
-);
-/* tslint:enable */
 
 /**
  * Command IDs for the extension.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,12 @@ import {
   NotebookModel
 } from '@jupyterlab/notebook';
 
-import { JSONExt, JSONObject, PromiseDelegate } from '@phosphor/coreutils';
+import {
+  JSONExt,
+  JSONObject,
+  PromiseDelegate,
+  Token
+} from '@phosphor/coreutils';
 
 import { DataGrid, TextRenderer } from '@phosphor/datagrid';
 
@@ -36,6 +41,7 @@ import { Widget } from '@phosphor/widgets';
 
 import {
   IOmniSciConnectionData,
+  IOmniSciConnectionManager,
   OmniSciCompletionConnector,
   showConnectionDialog
 } from './connection';
@@ -53,6 +59,15 @@ import {
  * The name of the factory that creates pdf widgets.
  */
 const FACTORY = 'OmniSciVega';
+
+/* tslint:disable */
+/**
+ * The OmniSciConnectionManager token.
+ */
+const IOmniSciConnectionManager = new Token<IOmniSciConnectionManager>(
+  'jupyterlab-omnisci:IOmniSciConnectionManager'
+);
+/* tslint:enable */
 
 /**
  * Command IDs for the extension.
@@ -175,6 +190,7 @@ function activateOmniSciConnection(
   mainMenu.settingsMenu.addGroup([{ command: CommandIDs.setConnection }], 50);
   palette.addItem({ command: CommandIDs.setConnection, category: 'OmniSci' });
 }
+
 /**
  * The OmniSci-Vega file type.
  */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,8 @@ async function activateOmniSciConnection(
     execute: () => {
       showConnectionDialog(
         'Set Default Omnisci Connection',
-        manager.defaultConnection
+        manager.defaultConnection,
+        manager.connections
       ).then(connection => {
         manager.defaultConnection = connection;
       });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,6 +126,7 @@ async function activateOmniSciConnection(
         manager.defaultConnection
       );
       manager.defaultConnection = connection;
+      return connection;
     },
     label: 'Set Default Omnisci Connection...'
   });
@@ -133,11 +134,9 @@ async function activateOmniSciConnection(
   // Add an application-wide connection-setting command.
   app.commands.addCommand(CommandIDs.setEnvironment, {
     execute: async () => {
-      const connection = await manager.chooseConnection(
-        'Set OmniSci Connection Environment Variables',
-        manager.environment
-      );
-      manager.environment = connection;
+      const environment = await manager.setEnvironment();
+      manager.environment = environment;
+      return environment;
     },
     label: 'Set OmniSci Connection Environment...'
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -380,8 +380,6 @@ function activateOmniSciGridViewer(
     selector: `.omnisci-OmniSci-toolbar .jp-Editor.jp-mod-completer-enabled`
   });
 
-  let defaultConnectionData: IOmniSciConnectionData | undefined;
-
   app.commands.addCommand(CommandIDs.newGrid, {
     label: 'OmniSci SQL Editor',
     iconClass: 'omnisci-OmniSci-logo',
@@ -389,7 +387,7 @@ function activateOmniSciGridViewer(
       const query = (args['initialQuery'] as string) || '';
       const grid = new OmniSciSQLEditor({
         editorFactory: editorServices.factoryService.newInlineEditor,
-        connectionData: defaultConnectionData
+        connectionData: manager.defaultConnection
       });
       grid.content.query = query;
       grid.id = `omnisci-grid-widget-${++Private.id}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,10 +114,7 @@ async function activateOmniSciConnection(
   settingRegistry: ISettingRegistry
 ): Promise<IOmniSciConnectionManager> {
   // Fetch the initial state of the settings.
-  const [settings] = await Promise.all([
-    settingRegistry.load(CONNECTION_PLUGIN_ID),
-    app.restored
-  ]);
+  const settings = await settingRegistry.load(CONNECTION_PLUGIN_ID);
   const manager = new OmniSciConnectionManager({ settings });
 
   // Add an application-wide connection-setting command.

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -173,10 +173,10 @@ export class OmniSciGrid extends Panel {
   /**
    * The current connection data for the viewer.
    */
-  get connectionData(): IOmniSciConnectionData {
+  get connectionData(): IOmniSciConnectionData | undefined {
     return this._model.connectionData;
   }
-  set connectionData(value: IOmniSciConnectionData) {
+  set connectionData(value: IOmniSciConnectionData | undefined) {
     this._updateModel(value, this._model.query);
   }
 
@@ -225,7 +225,7 @@ export class OmniSciGrid extends Panel {
    * validation failure, it shows the error in the panel.
    */
   private _updateModel(
-    connectionData: IOmniSciConnectionData,
+    connectionData: IOmniSciConnectionData | undefined,
     query: string
   ): void {
     const hasQuery = query !== '';
@@ -371,7 +371,7 @@ export class OmniSciTableModel extends DataModel {
       }
     } else {
       // If we are not streaming, then just return the loaded data.
-      const rowData = this._dataset[row];
+      const rowData = this._dataset![row];
       return rowData[this._fieldNames[column]];
     }
   }
@@ -388,7 +388,7 @@ export class OmniSciTableModel extends DataModel {
    *   an error if the validation fails.
    */
   updateModel(
-    connectionData: IOmniSciConnectionData,
+    connectionData: IOmniSciConnectionData | undefined,
     query: string
   ): Promise<void> {
     if (
@@ -451,9 +451,12 @@ export class OmniSciTableModel extends DataModel {
    * Fetch a block with a given index into memory.
    */
   private _fetchBlock(index: number): Promise<void> {
+    if (!this._connectionPromise) {
+      return Promise.resolve(void 0);
+    }
     // If we are already fetching this block, do nothing.
     if (this._pending.has(index)) {
-      return;
+      return Promise.resolve(void 0);
     }
     this._pending.add(index);
 
@@ -530,6 +533,9 @@ export class OmniSciTableModel extends DataModel {
    * limited by DEFAULT_LIMIT.
    */
   private _fetchDataset(): Promise<void> {
+    if (!this._connectionPromise) {
+      return Promise.resolve(void 0);
+    }
     return this._connectionPromise.then(connection => {
       return Private.makeQuery(connection, this._query, {
         limit: DEFAULT_LIMIT

--- a/src/mimeextensions.ts
+++ b/src/mimeextensions.ts
@@ -150,7 +150,7 @@ export class RenderedOmniSciSQLEditor extends Widget
       SQL_EDITOR_MIME_TYPE
     ] as unknown) as IOmniSciSQLEditorMimeBundle;
     if (!data) {
-      return;
+      return Promise.resolve(void 0);
     }
     this._widget.content.connectionData = data.connection;
     this._widget.content.query = data.query || '';

--- a/src/viewer.ts
+++ b/src/viewer.ts
@@ -62,10 +62,10 @@ export class OmniSciVegaViewer extends DocumentWidget<Widget> {
   /**
    * The current connection data for the viewer.
    */
-  get connectionData(): IOmniSciConnectionData {
+  get connectionData(): IOmniSciConnectionData | undefined {
     return this._connectionData;
   }
-  set connectionData(value: IOmniSciConnectionData) {
+  set connectionData(value: IOmniSciConnectionData | undefined) {
     this._connectionData = value;
   }
 
@@ -133,10 +133,10 @@ export class OmniSciVegaViewerFactory extends ABCWidgetFactory<
   /**
    * The current default connection data for viewers.
    */
-  get defaultConnectionData(): IOmniSciConnectionData {
+  get defaultConnectionData(): IOmniSciConnectionData | undefined {
     return this._defaultConnectionData;
   }
-  set defaultConnectionData(value: IOmniSciConnectionData) {
+  set defaultConnectionData(value: IOmniSciConnectionData | undefined) {
     this._defaultConnectionData = value;
   }
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -105,7 +105,7 @@ export class OmniSciVega extends Widget {
 
   private _rendered = new PromiseDelegate<string>();
   private _vega: JSONObject;
-  private _vegaLite: JSONObject;
+  private _vegaLite: JSONObject | undefined;
   private _connectionPromise: Promise<OmniSciConnection>;
   private _img: HTMLImageElement;
   private _error: HTMLElement;

--- a/style/index.css
+++ b/style/index.css
@@ -60,6 +60,7 @@
   font-family: monospace;
   background-color: var(--jp-layout-color0);
   border: var(--jp-border-width) solid var(--jp-border-color0);
+  margin-left: 12px;
 }
 
 .jp-Toolbar.omnisci-OmniSci-toolbar .jp-Editor.jp-mod-focused {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmitOnError": true,
     "noUnusedLocals": true,
     "skipLibCheck": true,
+    "strictNullChecks": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES6",


### PR DESCRIPTION
This is a major refactor of how connections that the extension knows about are populated. Instead of the several sub-plugins all reading from the same settings id, we create an `IOmniSciConnectionManager` token which is responsible for reading from the settings system. This connection manager can also check to see if there is an immerse server alongside JuyterLab and provide connection data for that server. 