### PR TITLE
Better ibis insert

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -542,6 +542,12 @@ export class OmniSciConnectionDialog extends Widget
       const option = document.createElement('option');
       option.value = `${idx++}`;
       option.textContent = server.host || 'Unknown host';
+      option.title = `Hostname: ${server.host || 'unknown'}
+Protocol: ${server.protocol || 'unknown'}
+Port: ${server.port || 'unknown'}
+Database: ${server.database || 'unknown'}
+User: ${server.username || 'unknown'}
+Password ${server.password ? '*****' : 'unknown'}`;
       select.appendChild(option);
     });
     return select;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -464,15 +464,19 @@ function activateOmniSciInitialNotebook(
 ): void {
   // Add a command to inject the ibis connection data into the active notebook.
   app.commands.addCommand(CommandIDs.injectIbisConnection, {
-    label: 'Inject Ibis OmniSci Connection',
-    execute: () => {
+    label: 'Insert Ibis OmniSci Connection…',
+    execute: async () => {
       const current = tracker.currentWidget;
       if (!current) {
         return;
       }
+      const connection = await manager.chooseConnection(
+        'Choose Ibis Connection',
+        manager.defaultConnection
+      );
       Private.injectIbisConnection(
         current.content,
-        manager.defaultConnection,
+        connection,
         manager.environment
       );
     },
@@ -637,7 +641,7 @@ con.list_tables()`.trim();
     value = value.replace('{{user}}', con.username || '""');
     value = value.replace('{{port}}', `${con.port || '""'}`);
     NotebookActions.insertAbove(notebook);
-    notebook.model.cells.get(0)!.value.text = value;
+    notebook.activeCell!.model.value.text = value;
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -448,6 +448,7 @@ const omnisciInitialNotebookPlugin: JupyterFrontEndPlugin<void> = {
   id: INITIAL_NOTEBOOK_PLUGIN_ID,
   requires: [
     ICommandPalette,
+    IMainMenu,
     INotebookTracker,
     IOmniSciConnectionManager,
     IStateDB
@@ -458,6 +459,7 @@ const omnisciInitialNotebookPlugin: JupyterFrontEndPlugin<void> = {
 function activateOmniSciInitialNotebook(
   app: JupyterFrontEnd,
   palette: ICommandPalette,
+  menu: IMainMenu,
   tracker: INotebookTracker,
   manager: IOmniSciConnectionManager,
   state: IStateDB
@@ -487,6 +489,7 @@ function activateOmniSciInitialNotebook(
     command: CommandIDs.injectIbisConnection,
     category: 'OmniSci'
   });
+  menu.editMenu.addGroup([{ command: CommandIDs.injectIbisConnection }], 50);
 
   // Fetch the state, which is used to determine whether to create
   // an initial populated notebook.


### PR DESCRIPTION
Small improvements to the UX of inserting an ibis connection in a notebook:
* Bring up a connection choosing dialog instead of just using the default.
* Don't always insert in the first notebook cell.
* Add hover text to select dropdown so the user can more easily see which preconfigured connection they are choosing.