### PR TITLE
 Don't load ipython magics unless running ipython is available

### DIFF
--- a/jupyterlab_omnisci/magics.py
+++ b/jupyterlab_omnisci/magics.py
@@ -12,9 +12,11 @@ import pymapd
 
 __all__ = ["OmniSciVegaRenderer", "OmniSciSQLEditorRenderer"]
 
+from IPython import get_ipython
 from IPython.core.magic import register_cell_magic
 from IPython.display import display
 
+ip = get_ipython()
 
 class OmniSciVegaRenderer:
     """
@@ -99,51 +101,6 @@ class OmniSciSQLEditorRenderer:
         data = {"connection": self.connection, "query": self.query}
         return {"application/vnd.omnisci.sqleditor+json": data}
 
-
-@register_cell_magic
-def omnisci_vega(line, cell):
-    """
-    Cell magic for rendering vega produced by the omnisci backend.
-
-    Usage: Initiate it with the line `%% omnisci $connection_data`,
-    where `connection_data` is the dictionary containing the connection
-    data for the OmniSci server. The rest of the cell should be yaml-specified
-    vega data.
-    """
-    connection_data = ast.literal_eval(line)
-    vega = yaml.load(cell)
-    display(OmniSciVegaRenderer(connection_data, vega))
-
-
-@register_cell_magic
-def omnisci_vegalite(line, cell):
-    """
-    Cell magic for rendering vega lite produced by the omnisci backend.
-
-    Usage: Initiate it with the line `%% omnisci $connection_data`,
-    where `connection_data` is the dictionary containing the connection
-    data for the OmniSci server. The rest of the cell should be yaml-specified
-    vega lite data.
-    """
-    connection_data = ast.literal_eval(line)
-    vl = yaml.load(cell)
-    display(OmniSciVegaRenderer(connection_data, vl_data=vl))
-
-
-@register_cell_magic
-def omnisci_sqleditor(line, cell):
-    """
-    Cell magic for rendering a SQL editor. 
-
-    Usage: Initiate it with the line `%% omnisci $connection_data`,
-    where `connection_data` is the dictionary containing the connection
-    data for the OmniSci server. The rest of the cell should be 
-    a SQL query for the initial value of the editor.
-    """
-    connection_data = ast.literal_eval(line)
-    display(OmniSciSQLEditorRenderer(connection_data, cell))
-
-
 def _make_connection(connection):
     """
     Given a connection client, return a dictionary with connection
@@ -171,3 +128,49 @@ def _make_connection(connection):
         )
     else:
         return connection
+
+
+if ip is not None:
+
+    @register_cell_magic
+    def omnisci_vega(line, cell):
+        """
+        Cell magic for rendering vega produced by the omnisci backend.
+
+        Usage: Initiate it with the line `%% omnisci $connection_data`,
+        where `connection_data` is the dictionary containing the connection
+        data for the OmniSci server. The rest of the cell should be yaml-specified
+        vega data.
+        """
+        connection_data = ast.literal_eval(line)
+        vega = yaml.load(cell)
+        display(OmniSciVegaRenderer(connection_data, vega))
+
+
+    @register_cell_magic
+    def omnisci_vegalite(line, cell):
+        """
+        Cell magic for rendering vega lite produced by the omnisci backend.
+
+        Usage: Initiate it with the line `%% omnisci $connection_data`,
+        where `connection_data` is the dictionary containing the connection
+        data for the OmniSci server. The rest of the cell should be yaml-specified
+        vega lite data.
+        """
+        connection_data = ast.literal_eval(line)
+        vl = yaml.load(cell)
+        display(OmniSciVegaRenderer(connection_data, vl_data=vl))
+
+
+    @register_cell_magic
+    def omnisci_sqleditor(line, cell):
+        """
+        Cell magic for rendering a SQL editor. 
+
+        Usage: Initiate it with the line `%% omnisci $connection_data`,
+        where `connection_data` is the dictionary containing the connection
+        data for the OmniSci server. The rest of the cell should be 
+        a SQL query for the initial value of the editor.
+        """
+        connection_data = ast.literal_eval(line)
+        display(OmniSciSQLEditorRenderer(connection_data, cell))

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,12 @@ setup(
     url="https://github.com/Quansight/jupyterlab-omnisci",  # Optional
     packages=find_packages(),
     install_requires=[
+        "jupyterlab>=1.0.0rc0",
+        "ibis-framework>=1.0.0",
+        "altair>=3.0.1",
+        "ipywidgets",
         "vdom",
         "pyyaml",
-        "altair==3.0.1",
-        "ipywidgets",
-        "ibis-framework==1.0.0",
-        "vega_datasets",
-        "jupyterlab==1.0.0a8"
+        "vega_datasets"
     ]
 )


### PR DESCRIPTION
The conda recipe build was failing due to the unavailability of a running ipython instance.

```bash
import: 'jupyterlab_omnisci'
Traceback (most recent call last):
  File "/home/conda/feedstock_root/build_artifacts/jupyterlab-omnisci_1561605187967/test_tmp/run_test.py", line 2, in <module>
    import jupyterlab_omnisci
  File "/home/conda/feedstock_root/build_artifacts/jupyterlab-omnisci_1561605187967/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.7/site-packages/jupyterlab_omnisci/__init__.py", line 2, in <module>
    from .magics import *
  File "/home/conda/feedstock_root/build_artifacts/jupyterlab-omnisci_1561605187967/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.7/site-packages/jupyterlab_omnisci/magics.py", line 103, in <module>
    @register_cell_magic
  File "/home/conda/feedstock_root/build_artifacts/jupyterlab-omnisci_1561605187967/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeho/lib/python3.7/site-packages/IPython/core/magic.py", line 229, in magic_deco
    raise NameError('Decorator can only run in context where '
NameError: Decorator can only run in context where `get_ipython` exists
```

```bash
import: 'jupyterlab_omnisci'
    from .magics import *
  File "/Users/grant/anaconda/conda-bld/jupyterlab-omnisci_1561607998179/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/python3.6/site-packages/jupyterlab_omnisci/magics.py", line 104, in <module>
    @register_cell_magic
  File "/Users/grant/anaconda/conda-bld/jupyterlab-omnisci_1561607998179/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehol/lib/python3.6/site-packages/IPython/core/magic.py", line 238, in magic_deco
    ip.register_magic_function(func, magic_kind, name)
AttributeError: 'NoneType' object has no attribute 'register_magic_function'
```

I added a conditional to check if `get_ipython()` returns a running ipython before using `@register_cell_magic`.

Once this is merged and/or published, the conda recipe should pass CI: https://github.com/conda-forge/staged-recipes/pull/8623